### PR TITLE
feat: Update backend to 2.0.2 and front to 3.2.4.

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -8,14 +8,14 @@ POSTGRES_VOLUME="volume_postgres"
 
 
 # ADempiere gRPC Server
-GRPC_SERVER_IMAGE="solopcloud/adempiere-backend:alpine-2.0.1"
+GRPC_SERVER_IMAGE="solopcloud/adempiere-backend:alpine-2.0.2"
 GRPC_SERVER_NAME=adempiere.grpc.server
 GRPC_SERVER_JWT_SECRET_KEY="A42CF908019918B1D9D9E04E596658345D162D4C0127A4C8365E8BDF6B015CC7"
 GRPC_SERVER_SERVICES_ENABLED="bank_statement_match; business; business_partner; core; dashboarding; dictionary; enrollment; express_movement; express_receipt; express_shipment; file_management; general_ledger; import_file_loader; in_out; invoice; issue_management; location_address; log; match_po_receipt_invoice; material_management; order; payment; payment_allocation; payment_print_export; payroll_action_notice; pos; product; record_management; report_management; security; store; time_control; time_record; user_interface; user_customization; workflow;"
 
 
 # Envoy Proxy Definition
-GRPC_PROXY_IMAGE="solopcloud/adempiere-grpc-proxy:2.0.1"
+GRPC_PROXY_IMAGE="solopcloud/adempiere-grpc-proxy:2.0.2"
 GRPC_PROXY_NAME="grpc.proxy"
 GRPC_PROXY_PORT=5555
 GRPC_PROXY_SERVER_HOST=${GRPC_SERVER_NAME}
@@ -29,7 +29,7 @@ GATEWAY_PORT=8080
 
 
 # ADempiere UI Vue
-VUE_UI_IMAGE="solopcloud/adempiere-vue:alpine-3.2.2"
+VUE_UI_IMAGE="solopcloud/adempiere-vue:alpine-3.2.3"
 VUE_UI_HOST="vue.ui"
 VUE_UI_API_URL="http://127.0.0.1:8080/api/"
 VUE_UI_PORT=80

--- a/docker-compose/api/file_management.conf
+++ b/docker-compose/api/file_management.conf
@@ -20,6 +20,7 @@ location /api/file-management/ {
 		# The problem is conecting with envoy proxy
 		# See: https://www.digitalocean.com/community/questions/how-to-solve-nginx-websocket-secure-wss-error-426-upgrade-required
 		proxy_http_version 1.1;
+		proxy_max_temp_file_size 0;
 		proxy_pass http://adempiere_backend/file-management/;
 	}
 

--- a/docker-compose/api/payroll_action_notice.conf
+++ b/docker-compose/api/payroll_action_notice.conf
@@ -20,7 +20,7 @@ location /api/payroll-action-notice/ {
 		# The problem is conecting with envoy proxy
 		# See: https://www.digitalocean.com/community/questions/how-to-solve-nginx-websocket-secure-wss-error-426-upgrade-required
 		proxy_http_version 1.1;
-		proxy_pass http://adempiere_backend/human-resources/;
+		proxy_pass http://adempiere_backend/payroll-action-notice/;
 	}
 
 	return 404; # Catch-all

--- a/docker-compose/api/user_customization.conf
+++ b/docker-compose/api/user_customization.conf
@@ -20,7 +20,7 @@ location /api/user-customization/ {
 		# The problem is conecting with envoy proxy
 		# See: https://www.digitalocean.com/community/questions/how-to-solve-nginx-websocket-secure-wss-error-426-upgrade-required
 		proxy_http_version 1.1;
-		proxy_pass http://adempiere_backend/customizations/;
+		proxy_pass http://adempiere_backend/user-customization/;
 	}
 
 	return 404; # Catch-all


### PR DESCRIPTION
## What's Changed Backend
* feat: `Action Payroll Notice` form by @EdwinBetanc0urt in https://github.com/solop-develop/adempiere-grpc-server/pull/610
* fix: User Customization end points. by @EdwinBetanc0urt in https://github.com/solop-develop/adempiere-grpc-server/pull/611
* fix: Delete attachment resource with `Resource Name`. by @EdwinBetanc0urt in https://github.com/solop-develop/adempiere-grpc-server/pull/612
* feat: Accouting elements by accouting schema. by @EdwinBetanc0urt in https://github.com/solop-develop/adempiere-grpc-server/pull/613
* fix: Entity with null values. by @EdwinBetanc0urt in https://github.com/solop-develop/adempiere-grpc-server/pull/614


## What's Changed Frontend
* Add Scroll in Charts by @elsiosanchez in https://github.com/solop-develop/frontend-core/pull/1662
* Fix: Support User Customization by @elsiosanchez in https://github.com/solop-develop/frontend-core/pull/1663
* fix: Open `Smart Browser` associated on window. by @EdwinBetanc0urt in https://github.com/solop-develop/frontend-core/pull/1664
* Fix: When you reset the filter to is null, it is burned and does not allow any changes to the filter by @elsiosanchez in https://github.com/solop-develop/frontend-core/pull/1665
* Fix: Payroll Action Notice by @elsiosanchez in https://github.com/solop-develop/frontend-core/pull/1658
* fix: Attachment shortcut. by @EdwinBetanc0urt in https://github.com/solop-develop/frontend-core/pull/1667
* fix: Save user customization. by @EdwinBetanc0urt in https://github.com/solop-develop/frontend-core/pull/1669

**Full Changelog**: https://github.com/solop-develop/frontend-core/compare/3.2.2...3.2.4


**Full Changelog**: https://github.com/solop-develop/adempiere-grpc-server/compare/2.0.1...2.0.2