### PR TITLE
feat: Update frontend to `3.5.3`.

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -11,6 +11,7 @@ DEFAULT_NETWORK="default-stack.network"
 ALLOWED_ORIGIN="${SERVER_NAME}"
 
 
+
 # SQL Database
 POSTGRES_IMAGE="postgres:13"
 POSTGRES_HOST="${STACK_NAME}.postgresql.service"
@@ -51,7 +52,7 @@ S3_GATEWAY_RS_IMAGE="openls/s3-gateway-rs:1.0.9"
 S3_GATEWAY_RS_HOST="${STACK_NAME}.s3.gateway.rs"
 S3_GATEWAY_RS_PORT=7879
 S3_GATEWAY_RS_EXTERNAL_PORT=${S3_GATEWAY_RS_PORT}
-S3_GATEWAY_RS_S3_URL="http://${SERVER_NAME}:9000" # Public dns or path to upload signed files
+S3_GATEWAY_RS_S3_URL="http://${SERVER_NAME}:${S3_EXTERNAL_PORT}" # Public dns or path to upload signed files
 S3_GATEWAY_RS_API_KEY="${S3_USER}"
 S3_GATEWAY_RS_SECRET_KEY="${S3_PASSWORD}"
 S3_GATEWAY_RS_BUCKET_NAME="${S3_BUCKET_NAME}"
@@ -67,6 +68,7 @@ ADEMPIERE_SITE_ZK_HOST="http://${SERVER_NAME}/webui"
 ADEMPIERE_SITE_SCHEDULER_HOST="http://${SERVER_NAME}/ui"
 
 
+
 # Adempiere UI ZK
 ADEMPIERE_ZK_IMAGE="openls/adempiere-zk-ui:jetty-1.0.8"
 ADEMPIERE_ZK_HOST="${STACK_NAME}.adempiere.zk"
@@ -76,6 +78,7 @@ ADEMPIERE_ZK_DB_PORT=${POSTGRES_PORT}
 ADEMPIERE_ZK_DB_NAME=${ADEMPIERE_DB_NAME}
 ADEMPIERE_ZK_DB_USER=${ADEMPIERE_DB_USER}
 ADEMPIERE_ZK_DB_PASSWORD=${ADEMPIERE_DB_PASSWORD}
+
 
 
 # ADempiere Processors
@@ -88,12 +91,12 @@ ADEMPIERE_PROCESSOR_DB_NAME=${ADEMPIERE_DB_NAME}
 ADEMPIERE_PROCESSOR_DB_USER=${ADEMPIERE_DB_USER}
 ADEMPIERE_PROCESSOR_DB_PASSWORD=${ADEMPIERE_DB_PASSWORD}
 
-
 # dKron task scheduler
 DKRON_IMAGE="dkron/dkron"
 DKRON_HOST="${STACK_NAME}.dkron"
 DKRON_PORT=8088
 DKRON_VOLUME="${STACK_NAME}.volume_dkron"
+
 
 
 # Zookeeper manage kafka brokers
@@ -102,10 +105,29 @@ ZOOKEEPER_HOST="${STACK_NAME}.zookeeper"
 ZOOKEEPER_PORT=2181
 
 ## Kafka queue manager
-KAFKA_BROKER_HOST="${SERVER_NAME}"
 KAFKA_IMAGE="confluentinc/cp-kafka:latest"
 KAFKA_HOST="${STACK_NAME}.kafka"
-KAFKA_PORT=29092
+KAFKA_BROKER_HOST="${SERVER_NAME}"
+KAFKA_EXTERNAL_PORT=29092
+
+# OpenSearch search engine
+OPENSEARCH_IMAGE="opensearchproject/opensearch:2.11.1"
+OPENSEARCH_HOST="${STACK_NAME}.opensearch"
+OPENSEARCH_PORT=9200
+OPENSEARCH_PERFORMANCE_PORT=9600
+OPENSEARCH_VOLUME="${STACK_NAME}.volume_opensearch"
+
+# OpenSearch restore db
+OPENSEARCH_SETUP_HOST="${STACK_NAME}.opensearch_setup"
+
+# OpenSearch API RESTful
+OPENSEARCH_GATEWAY_RS_IMAGE="openls/opensearch-gateway-rs:1.0.8"
+OPENSEARCH_GATEWAY_RS_HOST="${STACK_NAME}.opensearch.gateway.rs"
+OPENSEARCH_GATEWAY_RS_PORT=7879
+OPENSEARCH_GATEWAY_RS_EXTERNAL_PORT=${OPENSEARCH_GATEWAY_RS_PORT}
+OPENSEARCH_GATEWAY_RS_KAFKA_HOST="kafka:9092"
+OPENSEARCH_GATEWAY_RS_OPENSEARCH_URL="http://${OPENSEARCH_HOST}:${OPENSEARCH_PORT}"
+
 
 
 # ADempiere gRPC Server
@@ -127,7 +149,6 @@ GRPC_SERVER_SERVICES_ENABLED="bank_statement_match; business; business_partner; 
 	security; store; task_management; time_control; time_record; trial_balance_drillable; \
 	user_customization; user_interface; workflow;"
 
-
 # Envoy Proxy Definition
 GRPC_PROXY_IMAGE="envoyproxy/envoy:v1.27.0"
 GRPC_PROXY_HOST="${STACK_NAME}.grpc.proxy"
@@ -136,6 +157,7 @@ GRPC_PROXY_BACKEND_PORT=5555
 GRPC_PROXY_BACKEND_HOST=${GRPC_SERVER_HOST}
 GRPC_PROXY_PROCESSOR_HOST=${ADEMPIERE_PROCESSOR_HOST}
 GRPC_PROXY_PROCESSOR_PORT=5556
+
 
 
 # Nginx Gateway
@@ -147,30 +169,11 @@ GATEWAY_VOLUME="${STACK_NAME}.volume_nginx"
 
 
 # ADempiere UI Vue
-VUE_UI_IMAGE="solopcloud/adempiere-vue:alpine-3.5.1"
+VUE_UI_IMAGE="solopcloud/adempiere-vue:alpine-3.5.3"
 VUE_UI_HOST="${STACK_NAME}.vue.ui"
 VUE_UI_PORT=9526
 VUE_UI_API_URL="http://${SERVER_NAME}/api/"
 VUE_UI_PUBLIC_PATH="/vue/"
-
-
-# OpenSearch search engine
-OPENSEARCH_IMAGE="opensearchproject/opensearch:2.11.1"
-OPENSEARCH_HOST="${STACK_NAME}.opensearch"
-OPENSEARCH_PORT=9200
-OPENSEARCH_PERFORMANCE_PORT=9600
-OPENSEARCH_VOLUME="${STACK_NAME}.volume_opensearch"
-
-# OpenSearch restore db
-OPENSEARCH_SETUP_HOST="${STACK_NAME}.opensearch_setup"
-
-# OpenSearch API RESTful
-OPENSEARCH_GATEWAY_RS_IMAGE="openls/opensearch-gateway-rs:1.0.8"
-OPENSEARCH_GATEWAY_RS_HOST="${STACK_NAME}.opensearch.gateway.rs"
-OPENSEARCH_GATEWAY_RS_PORT=7879
-OPENSEARCH_GATEWAY_RS_EXTERNAL_PORT=${OPENSEARCH_GATEWAY_RS_PORT}
-OPENSEARCH_GATEWAY_RS_KAFKA_HOST="kafka:9092"
-OPENSEARCH_GATEWAY_RS_OPENSEARCH_URL="http://${OPENSEARCH_HOST}:${OPENSEARCH_PORT}"
 
 
 

--- a/docker-compose/docker-compose-auth.yml
+++ b/docker-compose/docker-compose-auth.yml
@@ -170,6 +170,12 @@ services:
     image: ${S3_GATEWAY_RS_IMAGE}
     container_name: ${S3_GATEWAY_RS_HOST}
     restart: ${GENERIC_RESTART}
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/7878; exit $?;'"
+      interval: 10s
+      retries: 60
+      start_period: 20s
+      timeout: 10s
     depends_on:
       s3.storage:
         condition: service_healthy
@@ -212,7 +218,7 @@ services:
       - volume_dkron:/dkron.data
     networks:
       - shared_network
-  
+
   opensearch-node:
     image: ${OPENSEARCH_IMAGE}
     container_name: ${OPENSEARCH_HOST}
@@ -226,7 +232,7 @@ services:
       interval: 10s
       retries: 60
       start_period: 20s
-      timeout: 10s 
+      timeout: 10s
     ulimits:
       memlock:
         soft: -1
@@ -243,7 +249,7 @@ services:
     #   - ${OPENSEARCH_PERFORMANCE_PORT}:9600 # required for Performance Analyzer
     networks:
       - shared_network
-  
+
   open-search-setup:
     build:
       context: opensearch/
@@ -259,8 +265,14 @@ services:
   zookeeper:
     image: ${ZOOKEEPER_IMAGE}
     container_name: ${ZOOKEEPER_HOST}
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${ZOOKEEPER_PORT}; exit $?;'"
+      interval: 10s
+      retries: 60
+      start_period: 20s
+      timeout: 10s
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_CLIENT_PORT: ${ZOOKEEPER_PORT}
       ZOOKEEPER_TICK_TIME: 2000
     # ports:
     #   - ${ZOOKEEPER_PORT}:2181
@@ -272,12 +284,12 @@ services:
     container_name: ${KAFKA_HOST}
     depends_on:
       - zookeeper
-    # ports:
-    #   - ${KAFKA_PORT}:29092
+    ports:
+      - ${KAFKA_EXTERNAL_PORT}:29092
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://${KAFKA_BROKER_HOST}:${KAFKA_PORT}
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:${ZOOKEEPER_PORT}
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://${KAFKA_BROKER_HOST}:${KAFKA_EXTERNAL_PORT}
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1

--- a/docker-compose/docker-compose-develop.yml
+++ b/docker-compose/docker-compose-develop.yml
@@ -70,6 +70,12 @@ services:
     image: ${S3_GATEWAY_RS_IMAGE}
     container_name: ${S3_GATEWAY_RS_HOST}
     restart: ${GENERIC_RESTART}
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/7878; exit $?;'"
+      interval: 10s
+      retries: 60
+      start_period: 20s
+      timeout: 10s
     depends_on:
       s3.storage:
         condition: service_healthy
@@ -109,7 +115,7 @@ services:
       - shared_network
 
   grpc.proxy:
-    image: ${GRPC_PROXY_IMAGE}
+    image: ${GRPC_PROXY_BACKEND_IMAGE}
     container_name: ${GRPC_PROXY_HOST}
     healthcheck:
       test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/5555; exit $?;'"
@@ -117,19 +123,59 @@ services:
       retries: 60
       start_period: 20s
       timeout: 10s
-    ports:
-     - ${GRPC_PROXY_BACKEND_PORT}:5555
-     # Processor Port
-     - ${GRPC_PROXY_PROCESSOR_PORT}:5556
-    volumes:
-      - ./envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro
-      - ./envoy/definitions/adempiere-grpc-server.pb:/data/adempiere-grpc-server.pb:ro
-      - ./envoy/definitions/adempiere-processors-service-service.pb:/data/adempiere-processors-service-service.pb:ro
+    environment:
+      SERVER_PORT: 5555
+      BACKEND_HOST: ${GRPC_PROXY_BACKEND_HOST}
+    # volumes:
+    #   - ./envoy/envoy.yaml:/etc/envoy/envoy.yaml:ro
+    #   - ./envoy/definitions/adempiere-grpc-server.pb:/data/adempiere-grpc-server.pb:ro
+    #   - ./envoy/definitions/adempiere-processors-service-service.pb:/data/adempiere-processors-service-service.pb:ro
     depends_on:
       - adempiere.grpc.server
       # - adempiere.processor
     networks:
     - shared_network
+
+  zookeeper:
+    image: ${ZOOKEEPER_IMAGE}
+    container_name: ${ZOOKEEPER_HOST}
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${ZOOKEEPER_PORT}; exit $?;'"
+      interval: 10s
+      retries: 60
+      start_period: 20s
+      timeout: 10s
+    environment:
+      ZOOKEEPER_CLIENT_PORT: ${ZOOKEEPER_PORT}
+      ZOOKEEPER_TICK_TIME: 2000
+    # ports:
+    #   - ${ZOOKEEPER_PORT}:2181
+    networks:
+      - shared_network
+
+  kafka:
+    image: ${KAFKA_IMAGE}
+    container_name: ${KAFKA_HOST}
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/29092; exit $?;'"
+      interval: 10s
+      retries: 60
+      start_period: 20s
+      timeout: 10s
+    depends_on:
+      zookeeper:
+        condition: service_healthy
+    ports:
+      - ${KAFKA_EXTERNAL_PORT}:29092
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:${ZOOKEEPER_PORT}
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://${KAFKA_BROKER_HOST}:${KAFKA_EXTERNAL_PORT}
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+    networks:
+      - shared_network
 
   opensearch-node:
     image: ${OPENSEARCH_IMAGE}
@@ -144,7 +190,7 @@ services:
       interval: 10s
       retries: 60
       start_period: 20s
-      timeout: 10s 
+      timeout: 10s
     ulimits:
       memlock:
         soft: -1
@@ -169,7 +215,7 @@ services:
     container_name: ${OPENSEARCH_SETUP_HOST}
     image: ${OPENSEARCH_SETUP_HOST}
     depends_on:
-       opensearch-node:
+      opensearch-node:
         condition: service_healthy
     networks:
       - shared_network
@@ -178,12 +224,20 @@ services:
     image: ${OPENSEARCH_GATEWAY_RS_IMAGE}
     container_name: ${OPENSEARCH_GATEWAY_RS_HOST}
     restart: ${GENERIC_RESTART}
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/7878; exit $?;'"
+      interval: 10s
+      retries: 60
+      start_period: 20s
+      timeout: 10s
     environment:
       KAFKA_HOST: ${OPENSEARCH_GATEWAY_RS_KAFKA_HOST}
       OPENSEARCH_URL: ${OPENSEARCH_GATEWAY_RS_OPENSEARCH_URL}
       ALLOWED_ORIGIN: ${ALLOWED_ORIGIN}
     depends_on:
-       opensearch-node:
+      opensearch-node:
+        condition: service_healthy
+      kafka:
         condition: service_healthy
     ports:
       - ${OPENSEARCH_GATEWAY_RS_PORT}:7878
@@ -198,6 +252,8 @@ services:
         condition: service_healthy
       # vue.ui:
       #   condition: service_healthy
+      s3.gateway.rs:
+        condition: service_started
       opensearch.gateway.rs:
         condition: service_started
       # adempiere.site:
@@ -206,15 +262,24 @@ services:
       - ${GATEWAY_PORT}:80
     volumes:
       - ./nginx/nginx.conf:/etc/nginx/nginx.conf
-      - ./nginx/upstreams/adempiere_backend.conf:/etc/nginx/api_upstreams_conf.d/adempiere_backend.conf
-      - ./nginx/upstreams/opensearch_gateway.conf:/etc/nginx/api_upstreams_conf.d/opensearch_gateway.conf
-      - ./nginx/api/backend/:/etc/nginx/api_conf.d/backend
-      - ./nginx/api/opensearch/:/etc/nginx/api_conf.d/opensearch
-      - ./nginx/gateway/api_gateway.conf:/etc/nginx/api_gateway.conf
       - ./nginx/api_json_errors.conf:/etc/nginx/api_json_errors.conf
+      - ./nginx/gateway/api_gateway_develop.conf:/etc/nginx/api_gateway.conf
       #- ./keys/api_keys.conf:/etc/nginx/api_keys.conf
+      # backend
+      - ./nginx/upstreams/adempiere_backend.conf:/etc/nginx/api_upstreams_conf.d/adempiere_backend.conf
+      - ./nginx/api/backend/:/etc/nginx/api_conf.d/backend/
+      # open search
+      - ./nginx/upstreams/opensearch_gateway.conf:/etc/nginx/api_upstreams_conf.d/opensearch_gateway.conf
+      - ./nginx/api/opensearch/:/etc/nginx/api_conf.d/opensearch/
+      # s3
+      - ./nginx/upstreams/s3_storage.conf:/etc/nginx/api_upstreams_conf.d/s3_storage.conf
+      - ./nginx/upstreams/s3_console_ui.conf:/etc/nginx/api_upstreams_conf.d/s3_console_ui.conf
+      - ./nginx/upstreams/s3_gateway_rs.conf:/etc/nginx/api_upstreams_conf.d/s3_gateway_rs.conf
+      - ./nginx/api/s3/:/etc/nginx/api_conf.d/s3/
     networks:
       - shared_network
+
+
 
 networks:
   shared_network:

--- a/docker-compose/docker-compose.yml
+++ b/docker-compose/docker-compose.yml
@@ -70,6 +70,12 @@ services:
     image: ${S3_GATEWAY_RS_IMAGE}
     container_name: ${S3_GATEWAY_RS_HOST}
     restart: ${GENERIC_RESTART}
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/7878; exit $?;'"
+      interval: 10s
+      retries: 60
+      start_period: 20s
+      timeout: 10s
     depends_on:
       s3.storage:
         condition: service_healthy
@@ -211,7 +217,7 @@ services:
       - volume_dkron:/dkron.data
     networks:
       - shared_network
-  
+
   opensearch-node:
     image: ${OPENSEARCH_IMAGE}
     container_name: ${OPENSEARCH_HOST}
@@ -225,7 +231,7 @@ services:
       interval: 10s
       retries: 60
       start_period: 20s
-      timeout: 10s 
+      timeout: 10s
     ulimits:
       memlock:
         soft: -1
@@ -258,8 +264,14 @@ services:
   zookeeper:
     image: ${ZOOKEEPER_IMAGE}
     container_name: ${ZOOKEEPER_HOST}
+    healthcheck:
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${ZOOKEEPER_PORT}; exit $?;'"
+      interval: 10s
+      retries: 60
+      start_period: 20s
+      timeout: 10s
     environment:
-      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_CLIENT_PORT: ${ZOOKEEPER_PORT}
       ZOOKEEPER_TICK_TIME: 2000
     # ports:
     #   - ${ZOOKEEPER_PORT}:2181
@@ -271,12 +283,12 @@ services:
     container_name: ${KAFKA_HOST}
     depends_on:
       - zookeeper
-    # ports:
-    #   - ${KAFKA_PORT}:29092
+    ports:
+      - ${KAFKA_EXTERNAL_PORT}:29092
     environment:
       KAFKA_BROKER_ID: 1
-      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://${KAFKA_BROKER_HOST}:${KAFKA_PORT}
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:{ZOOKEEPER_PORT}
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:9092,PLAINTEXT_HOST://${KAFKA_BROKER_HOST}:${KAFKA_EXTERNAL_PORT}
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
       KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1


### PR DESCRIPTION
- Update `frontend-core` service to `3.5.3`.
- Add healthcheck to `s3.gateway.rs` service.
- Add healthcheck to `zookeeper` service.
- Add `KAFKA_EXTERNAL_PORT` to `kafka` service.
- Add `kafka` and `zookeeper` on `docker-compose/docker-compose-develop.yml` file definition.
