### PR TITLE
Parametrize which Docker Compose file will be executed

### DIFF
--- a/docker-compose/start-all.sh
+++ b/docker-compose/start-all.sh
@@ -41,5 +41,36 @@ else
     echo "Directory \"$PERSISTENTDIR\" exists already: no need to create it"
 fi
 
+# Find out which Docker Compose file will be used.
+# The script must be called with the flag "-d" + one of the following parameters [auth, cache, develop, storage, vue, default]
+# e.g.: ./start-all.sh -d vue
+# If script is called without or with a wrong flag, 'default' will be taken.
+# e.g.: ./start-all.sh
+while getopts d: flag
+do
+    case "${flag}" in
+        d) docker_compose_option=${OPTARG};;
+        *) docker_compose_option=default;;
+    esac
+done
+echo "Script called with parameter: \"$docker_compose_option\"";
+    
+case "${docker_compose_option}" in
+    auth)    docker_compose_file=docker-compose-auth.yml;;
+    cache)   docker_compose_file=docker-compose-cache.yml;;
+    develop) docker_compose_file=docker-compose-develop.yml;;
+    storage) docker_compose_file=docker-compose-storage.yml;;
+    vue)     docker_compose_file=docker-compose-vue.yml;;
+    default) docker_compose_file=docker-compose.yml;;
+    *)       docker_compose_file=docker-compose.yml;;
+esac
+
+# Save Docker Compose file name in file .DOCKER_COMPOSE_FILE
+# This will be used in scripts stop-all.sh and stop-and-delete.all.sh to stop the started services.
+savefile=.DOCKER_COMPOSE_FILE
+echo $docker_compose_file > $savefile
+
+
+echo "Docker Compose will be executed with file: \"$docker_compose_file\"";
 cp env_template .env
-docker compose up -d
+docker compose -f $docker_compose_file up -d

--- a/docker-compose/stop-all.sh
+++ b/docker-compose/stop-all.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+
+# Script to stop all services of the Compose file.
+# The file must be called for stopping the services
+
+savefile=.DOCKER_COMPOSE_FILE
+if [ -e $savefile ]
+then
+    docker_compose_file=$(cat $savefile)
+else
+    docker_compose_file=docker-compose.yml
+fi
+
+echo "All services started with the Docker Compose file \"$docker_compose_file\" will be stopped"
+docker compose -f $docker_compose_file down
+
+# To avoid misunderstandings, the file is deleted
+if [ -e $savefile ]
+then
+    rm $savefile
+fi

--- a/docker-compose/stop-and-delete-all.sh
+++ b/docker-compose/stop-and-delete-all.sh
@@ -1,9 +1,25 @@
 #!/bin/bash
 
-# Script to stop all services, delete all containers, networks volumes and images of the Compose file.
+# Script to stop all services, delete all containers, networks volumes and images of the Docker Compose file.
 
+savefile=.DOCKER_COMPOSE_FILE
+if [ -e $savefile ]
+then
+    docker_compose_file=$(cat $savefile)
+else
+    docker_compose_file=docker-compose.yml
+fi
+
+echo "All services started with the Docker Compose file \"$docker_compose_file\" will be stopped"
 # -v --> include named volumes declared in the "volumes" section of the Compose file and anonymous volumes attached to containers.
-docker compose down -v
+docker compose -f $docker_compose_file down -v
+
+# To avoid misunderstandings, the file is deleted
+if [ -e $savefile ]
+then
+    rm $savefile
+fi
+
 docker rmi -f $(docker compose images -q)
 yes | docker system prune -a
 # docker volume rm $(docker volume ls -q)       # This would delete also other volumes.


### PR DESCRIPTION
Fixes: https://github.com/adempiere/adempiere-ui-gateway/issues/45

The files _start-all.sh_ and  _stop-and-delete-all.sh_ were modified.
The file _stop-all.sh_ was added.

When the services are started, the name of the used docker compose file  is stored in a local file named **.DOCKER_COMPOSE_FILE** which will be deleted when the services are stopped.

The reason: when docker compose is started with a specific docker compose file, it must be stopped with the same docker compose file:

Start services:
`docker-compose -f <DOCKER_COMPOSE_FILE> up -d`

Stop services:
`docker-compose -f <DOCKER_COMPOSE_FILE> down`

Usage to start the services with the **-d** flag:
`./start-all.sh  -d [auth, cache, develop, storage, vue, default]`
e.g.:
- _./start-all.sh  -d auth_
   for docker-compose-auth.yml 
- _./start-all.sh  -d cache_
   for docker-compose-cache.yml 
- _./start-all.sh  -d develop_
   for docker-compose-develop.yml 
- _./start-all.sh  -d storage_
   for docker-compose-storage.yml 
- _./start-all.sh  -d vue_
   for docker-compose-vue.yml 
- _./start-all.sh  -d default_
   for docker-compose.yml 
- _./start-all.sh_
   for docker-compose.yml (this is the **default**)

To stop the services, just execute
_./stop-all.sh_
The file **.DOCKER_COMPOSE_FILE** will be read and docker compose down will be called with this file.
The file **.DOCKER_COMPOSE_FILE** will be deleted in the end to avoid conflicts.

To stop all services, delete all containers, networks volumes and images of the Docker Compose file, call
_./stop-and-delete-all.sh_
Concerning the services stopping, the result is the same as _stop-all.sh_.

The selection could not be configured inside the Docker Compose files, .env or env_template because they are used **after** they are needed.