### PR TITLE
fix: `Porcessors` service with dynamic port.

### DIFF
--- a/docker-compose/07a-adempiere_processor_service.yml
+++ b/docker-compose/07a-adempiere_processor_service.yml
@@ -9,7 +9,7 @@
         condition: service_healthy
     restart: ${GENERIC_RESTART}
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/50059; exit $?;'"
+      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${ADEMPIERE_PROCESSOR_PORT}; exit $?;'"
       interval: 10s
       retries: 60
       start_period: 20s


### PR DESCRIPTION
Standard Stack
```bash
./start-all.sh -d
```

Auth Stack
```bash
./start-all.sh -d auth
```


#### After this changes

![imagen](https://github.com/adempiere/adempiere-ui-gateway/assets/20288327/c4ed1930-ec73-439e-b81d-7af41dd2c958)

#### Before this changes

![imagen](https://github.com/adempiere/adempiere-ui-gateway/assets/20288327/873d9c74-0024-4bc0-ba97-b14c157f8ba0)


#### Additional contest
related changes https://github.com/adempiere/adempiere-ui-gateway/pull/88


