### PR TITLE
fix: Docker compose `version` is obsolete.

### DIFF
--- a/docker-compose/90-docker_compose_HEADER.yml
+++ b/docker-compose/90-docker_compose_HEADER.yml
@@ -1,3 +1,1 @@
-version: "3.9"
-
 services:

--- a/docker-compose/docker-compose-auth.yml
+++ b/docker-compose/docker-compose-auth.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 name: services-gateway-auth
 
 # Example API for images

--- a/docker-compose/docker-compose-cache.yml
+++ b/docker-compose/docker-compose-cache.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 name: services-gateway-cache
 
 services:

--- a/docker-compose/docker-compose-develop.yml
+++ b/docker-compose/docker-compose-develop.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 name: services-gateway-develop
 
 services:

--- a/docker-compose/docker-compose-standard.yml
+++ b/docker-compose/docker-compose-standard.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 services:
   postgresql.service:
     build:

--- a/docker-compose/docker-compose-storage.yml
+++ b/docker-compose/docker-compose-storage.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 name: services-gateway-storage
 
 services:

--- a/docker-compose/docker-compose-vue.yml
+++ b/docker-compose/docker-compose-vue.yml
@@ -1,5 +1,3 @@
-version: "3.9"
-
 name: services-gateway-vue
 
 services:


### PR DESCRIPTION


![2024-05-01_14-17](https://github.com/adempiere/adempiere-ui-gateway/assets/20288327/14912026-7630-45d5-bc77-04f4f98f6e04)

