### PR TITLE
feat: Upgrade Keycloak version to `25.0.4-0`

### DIFF
--- a/docker-compose/.env
+++ b/docker-compose/.env
@@ -268,7 +268,7 @@ VUE_UI_PUBLIC_PATH="/vue/"
 
 # Keycloak identity and access management
 # KEYCLOAK_IMAGE="jboss/keycloak:16.1.1"
-KEYCLOAK_IMAGE="keycloak/keycloak:23.0.7"
+KEYCLOAK_IMAGE="keycloak/keycloak:25.0.4-0"
 KEYCLOAK_CONTAINER_NAME="${COMPOSE_PROJECT_NAME}.keycloak.service"
 KEYCLOAK_HOSTNAME="${CLIENT_NAME}.keycloak"
 KEYCLOAK_PORT=8080

--- a/docker-compose/env_template.env
+++ b/docker-compose/env_template.env
@@ -268,7 +268,7 @@ VUE_UI_PUBLIC_PATH="/vue/"
 
 # Keycloak identity and access management
 # KEYCLOAK_IMAGE="jboss/keycloak:16.1.1"
-KEYCLOAK_IMAGE="keycloak/keycloak:23.0.7"
+KEYCLOAK_IMAGE="keycloak/keycloak:25.0.4-0"
 KEYCLOAK_CONTAINER_NAME="${COMPOSE_PROJECT_NAME}.keycloak.service"
 KEYCLOAK_HOSTNAME="${CLIENT_NAME}.keycloak"
 KEYCLOAK_PORT=8080


### PR DESCRIPTION
In Keycloak versions older than `25.0.4-0`, when using gRPC backend and proxy higher than `3.5.8`, you will receive an InvalidKeyException when trying to authenticate at login. The error message indicates that the key provided for RS256 verification is a SecretKeySpec instead of a PublicKey.

Error:
- `Caused by: io.jsonwebtoken.security.InvalidKeyException: RS256 verification keys must be PublicKeys (implements java.security.PublicKey). Provided key type: javax.crypto.spec.SecretKeySpec.`