### PR TITLE
Change Kafka healthcheck test command

### DIFF
--- a/docker-compose/13a-kafka_service.yml
+++ b/docker-compose/13a-kafka_service.yml
@@ -9,9 +9,9 @@
       zookeeper:
         condition: service_healthy
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${KAFKA_PORT}; exit $?;'"
-      interval: 10s
-      retries: 60
+      test: [ "CMD-SHELL", "/usr/bin/kafka-topics --bootstrap-server localhost:${KAFKA_PORT} --list "]
+      interval: 15s
+      retries: 3
       start_period: 20s
       timeout: 10s
     environment:

--- a/docker-compose/13b-kafka_service_with_kafdrop.yml
+++ b/docker-compose/13b-kafka_service_with_kafdrop.yml
@@ -9,9 +9,9 @@
       zookeeper:
         condition: service_healthy
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${KAFKA_PORT}; exit $?;'"
-      interval: 10s
-      retries: 60
+      test: [ "CMD-SHELL", "/usr/bin/kafka-topics --bootstrap-server localhost:${KAFKA_PORT} --list "]
+      interval: 15s
+      retries: 3
       start_period: 20s
       timeout: 10s
     environment:

--- a/docker-compose/docker-compose-auth.yml
+++ b/docker-compose/docker-compose-auth.yml
@@ -401,9 +401,9 @@ services:
       zookeeper:
         condition: service_healthy
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${KAFKA_PORT}; exit $?;'"
-      interval: 10s
-      retries: 60
+      test: [ "CMD-SHELL", "/usr/bin/kafka-topics --bootstrap-server localhost:${KAFKA_PORT} --list "]
+      interval: 15s
+      retries: 3
       start_period: 20s
       timeout: 10s
     environment:

--- a/docker-compose/docker-compose-cache.yml
+++ b/docker-compose/docker-compose-cache.yml
@@ -213,9 +213,9 @@ services:
       zookeeper:
         condition: service_healthy
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${KAFKA_PORT}; exit $?;'"
-      interval: 10s
-      retries: 60
+      test: [ "CMD-SHELL", "/usr/bin/kafka-topics --bootstrap-server localhost:${KAFKA_PORT} --list "]
+      interval: 15s
+      retries: 3
       start_period: 20s
       timeout: 10s
     # ports:

--- a/docker-compose/docker-compose-develop.yml
+++ b/docker-compose/docker-compose-develop.yml
@@ -356,9 +356,9 @@ services:
       zookeeper:
         condition: service_healthy
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${KAFKA_PORT}; exit $?;'"
-      interval: 10s
-      retries: 60
+      test: [ "CMD-SHELL", "/usr/bin/kafka-topics --bootstrap-server localhost:${KAFKA_PORT} --list "]
+      interval: 15s
+      retries: 3
       start_period: 20s
       timeout: 10s
     environment:

--- a/docker-compose/docker-compose-standard.yml
+++ b/docker-compose/docker-compose-standard.yml
@@ -351,9 +351,9 @@ services:
       zookeeper:
         condition: service_healthy
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${KAFKA_PORT}; exit $?;'"
-      interval: 10s
-      retries: 60
+      test: [ "CMD-SHELL", "/usr/bin/kafka-topics --bootstrap-server localhost:${KAFKA_PORT} --list "]
+      interval: 15s
+      retries: 3
       start_period: 20s
       timeout: 10s
     environment:


### PR DESCRIPTION
Solves #125 

With the present modifications, the Kafka log isn't cluttered anymore:
![Selection_590](https://github.com/user-attachments/assets/7d37f8cc-2898-420f-84ae-098bf91a8727)


Testing of this PR is simple: just start all services and verify that the Kafka log doesn't show any exceptions.