### PR TITLE
change zookeeper healthcheck

### DIFF
--- a/docker-compose/12a-zookeeper_service.yml
+++ b/docker-compose/12a-zookeeper_service.yml
@@ -5,7 +5,7 @@
     container_name: ${ZOOKEEPER_CONTAINER_NAME}
     hostname: ${ZOOKEEPER_HOSTNAME}
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${ZOOKEEPER_PORT}; exit $?;'"
+      test: echo srvr | nc localhost 2181 | grep Mode  # get info from zookeeper server
       interval: 10s
       retries: 60
       start_period: 20s

--- a/docker-compose/docker-compose-auth.yml
+++ b/docker-compose/docker-compose-auth.yml
@@ -376,7 +376,7 @@ services:
     container_name: ${ZOOKEEPER_CONTAINER_NAME}
     hostname: ${ZOOKEEPER_HOSTNAME}
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${ZOOKEEPER_PORT}; exit $?;'"
+      test: echo srvr | nc localhost 2181 | grep Mode  # get info from zookeeper server
       interval: 10s
       retries: 60
       start_period: 20s

--- a/docker-compose/docker-compose-cache.yml
+++ b/docker-compose/docker-compose-cache.yml
@@ -188,7 +188,7 @@ services:
     container_name: ${ZOOKEEPER_CONTAINER_NAME}
     hostname: ${ZOOKEEPER_HOSTNAME}
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${ZOOKEEPER_PORT}; exit $?;'"
+      test: echo srvr | nc localhost 2181 | grep Mode  # get info from zookeeper server
       interval: 10s
       retries: 60
       start_period: 20s

--- a/docker-compose/docker-compose-develop.yml
+++ b/docker-compose/docker-compose-develop.yml
@@ -330,7 +330,7 @@ services:
     container_name: ${ZOOKEEPER_CONTAINER_NAME}
     hostname: ${ZOOKEEPER_HOSTNAME}
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${ZOOKEEPER_PORT}; exit $?;'"
+      test: echo srvr | nc localhost 2181 | grep Mode  # get info from zookeeper server
       interval: 10s
       retries: 60
       start_period: 20s

--- a/docker-compose/docker-compose-standard.yml
+++ b/docker-compose/docker-compose-standard.yml
@@ -325,7 +325,7 @@ services:
     container_name: ${ZOOKEEPER_CONTAINER_NAME}
     hostname: ${ZOOKEEPER_HOSTNAME}
     healthcheck:
-      test: "bash -c 'printf \"GET / HTTP/1.1\n\n\" > /dev/tcp/127.0.0.1/${ZOOKEEPER_PORT}; exit $?;'"
+      test: echo srvr | nc localhost 2181 | grep Mode  # get info from zookeeper server
       interval: 10s
       retries: 60
       start_period: 20s


### PR DESCRIPTION
As @EdwinBetanc0urt  commented in pull Request https://github.com/adempiere/adempiere-ui-gateway/pull/126#issuecomment-2425255326 , the Zookeeper container logs an exception every 10 seconds:
![Selection_642](https://github.com/user-attachments/assets/b9ab8df6-2e22-46bf-8353-a0abdafc0045)

I found it might be because of the health check used.

Once the healthcheck command was modified, the exceptions disappear:
![image](https://github.com/user-attachments/assets/e3318a76-81c7-4446-908b-29d94b44252a)


@EdwinBetanc0urt Edwin, it maybe of interest to you.