### PR TITLE
Add links to adempiere-deployment-and-installation and quickstart index

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Due to the technology used, it is highly recommended to have a good knowledge of
 - **Customizations are non-invasive** — organization-specific logic is compiled into separate derived images; official upstream images are never modified, so upstream releases can be pulled in without touching local changes.
 - **Build and deploy are decoupled** — the customizations repository builds and publishes on its own cycle; the stack consumes only the resulting image tag, so a deployment update is a one-line version bump in `env_template.env`.
 - **One fork, many installations** — the same customizations fork can be reused across multiple `adempiere-ui-gateway` deployments (different clients, environments, regions) by referencing the same image tag.
+- **Ansible-automated server deployment** — [adempiere-deployment-and-installation](https://github.com/adempiere/adempiere-deployment-and-installation) sets up a production-ready server from scratch: OS hardening, Docker installation, repository clone, and application start with health check — all from your control machine with a single script, no manual steps required.
 
 
 ### Current Limitation — HTTP Only
@@ -58,6 +59,7 @@ Please follow the links for detailed information.
 - [Architecture](docs/architecture.md)
 - [Profiles](docs/profiles.md)
 - [Installation](docs/installation.md)
+- [Automated Server Deployment](https://github.com/adempiere/adempiere-deployment-and-installation) — Ansible project for deploying on a fresh VPS
 - [Display Services](docs/services.md)
 - [Security Information](docs/security.md)
 - [Backup and Restore](docs/backup-restore.md)

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -7,6 +7,14 @@
 > Java runs inside the Docker containers and is already included in the images.
 > This is one of the main benefits of using Docker!
 
+### Automated Server Deployment
+
+> **Deploying on a fresh VPS or dedicated server?** The [**adempiere-deployment-and-installation**](https://github.com/adempiere/adempiere-deployment-and-installation) Ansible project automates OS hardening, Docker installation, repository clone, and application start with health check — no manual steps required on the target server.
+>
+> The steps below cover the **manual** setup for a machine where Docker and Git are already installed.
+
+---
+
 ### Index
 
 | Step | Description |

--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -6,6 +6,35 @@
 > Java runs inside the Docker containers and is already included in the images.  
 > This is one of the main benefits of using Docker!
 
+### Automated Server Deployment
+
+> **Deploying on a fresh VPS or dedicated server?** The companion project
+> [**adempiere-deployment-and-installation**](https://github.com/adempiere/adempiere-deployment-and-installation)
+> automates the entire setup from a blank machine: OS hardening, Docker installation, repository clone,
+> two-phase application start, and health check — all from your control machine with a single script.
+>
+> This Quick Start guide covers the **manual** setup on a machine where Docker and Git are already installed.
+
+---
+
+### Index
+
+| Section | Description |
+|---------|-------------|
+| [Automated Server Deployment](#automated-server-deployment) | Ansible-based setup for a fresh VPS |
+| [What You Need](#what-you-need) | Required tools and versions |
+| [Clone the Repository](#clone-the-repository) | Get the code |
+| [Set Host-Specific Values](#set-host-specific-values) | Configure IP and settings |
+| [Start the Stack](#start-the-stack) | Run start-all.sh |
+| [Check the Application](#check-the-application) | Open in browser |
+| [Verify All Services (CLI)](#verify-all-services-cli) | Run health-check.sh |
+| [Full Restart + Health Check](#full-restart--health-check) | full-restart-with-healthcheck.sh |
+| [Validate All Profiles](#validate-all-profiles) | test-all-profiles.sh |
+| [FAQ](#frequently-asked-questions) | Common questions answered |
+| [Key Configuration Variables](#key-configuration-variables) | Variable reference |
+
+---
+
 ### What You Need
 
 ✓ Docker (20.10 or later)  


### PR DESCRIPTION
Links to the companion repository https://github.com/adempiere/adempiere-deployment-and-installation in the following files:
- README: new benefit bullet and TOC entry for the Ansible deployment project
- docs/quickstart.md: new index table + Automated Server Deployment callout
- docs/installation.md: Automated Server Deployment callout before the index