### PR TITLE
docs: remove references to non-existent default/standard/develop profiles

### DIFF
--- a/docs/installation.md
+++ b/docs/installation.md
@@ -75,13 +75,13 @@ Execute script `start-all.sh [all, auth, cache, report, scheduler, storage, vue,
 cd docker-compose
 ```
 
-- Default/Standard profile/stack:
+- Default stack — the `all` profile (started when no argument is given):
 ```shell
 ./start-all.sh
 ```
-Or:
+Or name the profile explicitly:
 ```shell
-./start-all.sh -d default
+./start-all.sh all
 ```
 
 - Authentication (`auth`) profile/stack:

--- a/docs/profiles.md
+++ b/docs/profiles.md
@@ -48,7 +48,7 @@ The script discovers which containers were actually started after `start-all.sh`
 
 | Profile | Key | Description |
 |---------|-----|-------------|
-| [Default / Standard](#services-activated-with-defaultstandard-profile-no-parameter-or-empty-string) | _(no parameter)_ | Production-ready core stack (ZK + Vue + gRPC) |
+| [Default (no argument)](#services-activated-with-no-argument-the-all-profile) | _(no parameter)_ | Runs the `all` profile — the complete stack |
 | [Authentication](#services-activated-with-authentication-profile) | `auth` | Core stack with Keycloak identity provider |
 | [Dictionary Cache](#services-activated-with-dictionary-cache-profile) | `cache` | Adds Kafka + OpenSearch + dictionary-rs caching layer |
 | [Dictionary Report Engine](#services-activated-with-dictionary-report-engine-profile) | `report` | Adds report engine service |
@@ -59,23 +59,14 @@ The script discovers which containers were actually started after `start-all.sh`
 | [All](#services-activated-with-all-profile) | `all` | Complete stack with all available services |
 | [Multiple profiles](#multiple-profiles) | combined | Combining multiple profile keys |
 
-#### Services activated with _Default/Standard_ Profile (No parameter or empty string)
-This is the **production-ready stack** with all core ADempiere services. This profile runs when you execute `./start-all.sh` without any parameter.
-
- - postgres-service
- - adempiere-site
- - adempiere-zk
- - vue-ui
- - vue-grpc-server
- - adempiere-grpc-server
- - grpc-proxy
- - ui-gateway
+#### Services activated with no argument (the `all` profile)
+There is **no** profile literally named `default` or `standard`. Running `./start-all.sh` **without any argument** activates the **`all`** profile — the complete stack with every service (listed under [All](#services-activated-with-all-profile) below).
 
 ![ADempiere Standard Architecture](architecture/architecture-all.png)
 
 Start with:
 ```bash
-./start-all.sh
+./start-all.sh          # equivalent to ./start-all.sh all
 ```
 
 **Note:** This is the recommended stack for production deployments.
@@ -227,7 +218,7 @@ Start with:
 COMPOSE_PROFILES="report,vue,zk" docker compose up
 ```
 
-**Note:** The default profile (empty string `''`) is always included unless you explicitly specify other profiles.
+**Note:** Only the profiles you pass are activated — there is no automatically-included "default" profile. A service starts only when one of its declared profiles is active (the empty-string profile `''` behaves like `all`, starting the full stack).
 
 
 ---

--- a/docs/security.md
+++ b/docs/security.md
@@ -93,7 +93,7 @@ networks:
 **Security considerations:**
 - Change default subnet if it conflicts with your network
 - Only expose ports that require external access
-- Use `develop` profile cautiously (exposes more ports)
+- Expose additional ports cautiously (development environments only)
 
 See [Architecture - Network Architecture](./architecture.md#network-architecture) for details.
 
@@ -206,17 +206,17 @@ docker compose ps | grep processor
 **Security measures:**
 
 1. **Network isolation:**
-   - Default: Internal only (no external port in `standard` profile)
-   - Develop mode: Port 55432 exposed (for debugging only)
+   - Default: internal only (no external DB port)
+   - Development: port 55432 exposed for debugging only
    - Production: Never expose externally
 
 2. **Access control:**
    ```bash
-   # Production: Use standard profile (no external DB port)
+   # Production: default startup; the DB port is controlled in .env
    ./start-all.sh
 
-   # Development: Exposes port 55432
-   ./start-all.sh -d develop
+   # Development: same startup — set POSTGRES_EXTERNAL_PORT in .env to publish port 55432
+   ./start-all.sh
    ```
 
 3. **Firewall rules:**
@@ -256,8 +256,8 @@ docker compose ps | grep processor
 **Security considerations:**
 
 1. **Default credentials:** admin/admin (change in production)
-2. **Dashboards access:** Only expose on `develop` profile
-3. **Production:** Use `standard` profile (no dashboard access)
+2. **Dashboards access:** Only expose in development environments
+3. **Production:** Do not expose dashboards
 4. **Data sensitivity:** Contains dictionary metadata (not business data)
 
 ### MinIO S3 Storage
@@ -307,12 +307,12 @@ Internal Docker Network (192.168.100.0/24)
 
 ### Port Exposure Strategy
 
-**Standard/Production Profile:**
+**Production setup:**
 - **Port 80 (HTTP):** nginx API gateway ONLY
 - **No other ports exposed**
 - All services accessed via nginx reverse proxy
 
-**Develop Profile:**
+**Development setup:**
 - Port 80: nginx
 - Port 55432: PostgreSQL (⚠️ development only)
 - Port 5601: OpenSearch Dashboards (⚠️ development only)
@@ -741,7 +741,7 @@ Use this checklist before going to production:
 - [ ] SSH password authentication disabled
 - [ ] SSH keys configured for all admins
 - [ ] Processor Service has no external ports (verify)
-- [ ] PostgreSQL has no external port in production (use `standard` profile)
+- [ ] PostgreSQL has no external port in production
 - [ ] Backup directory permissions restricted (chmod 700)
 - [ ] `.env` file not committed to version control
 - [ ] Backup encryption implemented


### PR DESCRIPTION

The docs named profiles that do not exist in docker-compose.yml. The only real profiles are: all, auth, cache, report, scheduler, storage, vue, zk.

- profiles.md / installation.md: "Default/Standard" is not a profile. Running `start-all.sh` with no argument activates the `all` profile (the complete stack), so the "default" case is documented as `all`.
- security.md: there is no `develop`/`standard` profile. PostgreSQL's external port (55432) is governed by the POSTGRES_EXTERNAL_PORT env var in .env, not by a profile; wording updated accordingly.