### PR TITLE
docs: Don't use destructive stop-and-delete-all.sh for a routing restart

### DIFF
--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -633,12 +633,14 @@ sudo ip link set wlan0 down
 nmcli device disconnect wlan0
 ```
 
-Then stop and restart the full stack:
+Then restart the full stack so Docker recreates the containers and the bridge network:
 
 ```bash
-sudo ./stop-and-delete-all.sh
+sudo ./stop-all.sh      # docker compose down — removes containers and network, keeps the database volume
 sudo ./start-all.sh
 ```
+
+> **Do not** use `stop-and-delete-all.sh` here: it is interactive and destructive (`docker compose down -v` plus `docker rmi` and `docker system prune -a`), so it deletes the database volume and all images. A routing fix only needs the containers and network recreated, which `stop-all.sh` + `start-all.sh` does without data loss.
 
 With a single active interface, Docker's bridge routing is unambiguous and all services start correctly.
 


### PR DESCRIPTION
The "Two Network Interfaces" fix told the reader to run `stop-and-delete-all.sh` followed by `start-all.sh` to restart the stack. That script is interactive and destructive: it runs `docker compose down -v` (deletes named volumes, including the PostgreSQL data volume), `docker rmi` (removes images) and `docker system prune -a`. Using it as a "restart" wipes the database and forces a full re-download of every image.

Recreating the containers and the bridge network — which is all a routing fix needs — is done by `stop-all.sh` (`docker compose down`, keeps volumes) + `start-all.sh`. Updated the step accordingly and added a warning about the destructive script.