### PR TITLE
docs: auto-restore seed must be a custom-format dump (pg_restore)

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -301,8 +301,10 @@ The stack automatically restores from a seed file on first startup:
 - The `initdb.sh` script runs when PostgreSQL container starts
 - Checks if database "adempiere" exists
 - If not, looks for `seed.backup` file
-- Restores database from seed file
+- Restores database from the seed file **with `pg_restore`**
 - If no seed file found, downloads latest from GitHub
+
+> **Important — the seed must be a custom-format dump.** `initdb.sh` restores `seed.backup` with `pg_restore`, which only reads PostgreSQL's **custom format** (`pg_dump --format=custom`, see [Custom Format Backup](#custom-format-backup-advanced)). A plain-SQL dump — the `.backup` produced by the quick and compressed procedures above — will **not** work as an auto-restore seed. To restore a plain-SQL dump, use the [Manual Restore](#manual-restore-existing-database) procedure (`psql`) instead.
 
 **To trigger automatic restore:**
 
@@ -314,8 +316,8 @@ cd docker-compose/
 # 2. Delete database directory
 sudo rm -rf postgresql/postgres_database/*
 
-# 3. Copy your backup as seed file
-cp postgresql/postgres_backups/adempiere-2026-02-13-103045.backup postgresql/postgres_backups/seed.backup
+# 3. Copy a CUSTOM-FORMAT backup as the seed file (auto-restore uses pg_restore)
+cp postgresql/postgres_backups/adempiere-2026-02-13-103045.custom postgresql/postgres_backups/seed.backup
 
 # 4. Start stack - restore happens automatically
 ./start-all.sh
@@ -789,7 +791,7 @@ If your server crashes or becomes unrecoverable:
 5. **Place database backup:**
    ```bash
    mkdir -p postgresql/postgres_backups
-   cp /path/to/backup/adempiere-latest.backup postgresql/postgres_backups/seed.backup
+   cp /path/to/backup/adempiere-latest.custom postgresql/postgres_backups/seed.backup   # must be a custom-format dump (restored with pg_restore)
    ```
 6. **Start stack** (automatic restore will occur):
    ```bash


### PR DESCRIPTION
When a user supplies their own seed.backup, initdb.sh restores it with `pg_restore` (the psql branch is legacy/disabled and IS_PSQL is never set on that path). `pg_restore` only reads PostgreSQL's custom format (`pg_dump --format=custom`).

The Automatic Restore instructions told the reader to copy a plain-SQL `.backup` (the output of the quick/compressed procedures, `pg_dump > file`) as the seed, which pg_restore cannot read — the automatic restore fails silently.

- Automatic Restore: state that the restore uses `pg_restore` and add a note that the seed must be a custom-format dump; point to Manual Restore (psql) for plain-SQL dumps.
- Corrected the "copy your backup as seed" example and the disaster-recovery step to use a `.custom` file.