### PR TITLE
docs: Fix wrong Vue/ZK service and container names in debugging.md

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -123,9 +123,9 @@ docker compose rm -s -f postgresql-service
 docker compose up -d <service-name>
 
 # Example: Recreate ZK UI container
-docker compose stop adempiere-zk-service
-docker compose rm -f adempiere-zk-service
-docker compose up -d adempiere-zk-service
+docker compose stop adempiere-zk
+docker compose rm -f adempiere-zk
+docker compose up -d adempiere-zk
 ```
 
 **When to recreate:**
@@ -666,12 +666,12 @@ See [Troubleshooting - Container Health Checks](./troubleshooting.md#container-h
 3. **Check backend service:**
    ```bash
    # For ZK UI
-   docker compose ps adempiere-zk-service
+   docker compose ps adempiere-zk
    docker container logs adempiere-ui-gateway.zk
 
    # For Vue UI
-   docker compose ps adempiere-vue-service
-   docker container logs adempiere-ui-gateway.vue
+   docker compose ps vue-ui
+   docker container logs adempiere-ui-gateway.vue-ui
    ```
 
 4. **Test from inside nginx:**


### PR DESCRIPTION
## Summary
- Several `debugging.md` commands referenced service and container names that do not exist, so they silently do nothing (or fail) when copy-pasted.

## Changes
- `docs/debugging.md`:
  - `adempiere-zk-service` → `adempiere-zk` (the real Compose **service** name) — 4 occurrences (the "Recreate ZK UI container" example and the backend-check block).
  - `adempiere-vue-service` → `vue-ui` (the real Compose **service** name).
  - `adempiere-ui-gateway.vue` → `adempiere-ui-gateway.vue-ui` (the real **container** name).
- The ZK container name `adempiere-ui-gateway.zk` was already correct and is left unchanged.

## Why
Service names come from `docker-compose.yml` (`adempiere-zk`, `vue-ui`); container names come from `env_template.env` (`VUE_UI_CONTAINER_NAME="${COMPOSE_PROJECT_NAME}.vue-ui"`, `ADEMPIERE_ZK_CONTAINER_NAME="${COMPOSE_PROJECT_NAME}.zk"`). Neither `adempiere-zk-service` nor `adempiere-vue-service` is a defined service, and the Vue container is `.vue-ui`, not `.vue`.

## How to test (before / after)
Non-destructive — these only resolve/list names, they do not start or stop anything.

**Verify which service names actually exist:**
```bash
cd docker-compose/
docker compose config --services | sort
# Present:  adempiere-zk , vue-ui
# Absent:   adempiere-zk-service , adempiere-vue-service
```

**Before** — the documented names resolve to nothing:
```bash
cd docker-compose/
docker compose ps adempiere-zk-service     # no such service → empty result
docker compose ps adempiere-vue-service    # no such service → empty result
```

**After** — the corrected names resolve to the real services:
```bash
cd docker-compose/
docker compose ps adempiere-zk             # shows the ZK service
docker compose ps vue-ui                   # shows the Vue UI service
```

**Confirm the Vue container name** (`.vue-ui`, not `.vue`):
```bash
grep VUE_UI_CONTAINER_NAME docker-compose/env_template.env
# VUE_UI_CONTAINER_NAME="${COMPOSE_PROJECT_NAME}.vue-ui"
```

## Reviewer checklist
- [ ] `docker compose config --services` lists `adempiere-zk` and `vue-ui`, and does **not** list `adempiere-zk-service` or `adempiere-vue-service`
- [ ] No remaining `adempiere-vue-service` / `adempiere-zk-service` in `docs/debugging.md`
- [ ] The correct `adempiere-ui-gateway.zk` references were left unchanged