### PR TITLE
docs: use the real Docker Compose DB health check in backup-restore.md

### DIFF
--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -560,8 +560,7 @@ Run the same health check used by Docker Compose:
 # Manual health check
 docker exec adempiere-ui-gateway.postgresql bash -c \
   "pg_isready -U postgres && \
-   psql -U adempiere -d adempiere -t -c \
-   'SELECT COUNT(*) FROM information_schema.tables WHERE table_schema = '\''adempiere'\''' | grep -q '760'"
+   psql -U adempiere -d adempiere -c 'SELECT Version FROM AD_SYSTEM'"
 
 # If exit code is 0, database is healthy
 echo $?


### PR DESCRIPTION
The "Health Check for Restored Database" section claimed to run "the same health check used by Docker Compose", but used a different query: `SELECT COUNT(*) FROM information_schema.tables ... | grep -q '760'`.

The actual health check in docker-compose.yml (postgresql-service) is: `pg_isready -U postgres && psql -U ${ADEMPIERE_DB_USER} -d ${ADEMPIERE_DB_NAME} -c 'SELECT Version FROM AD_SYSTEM'`

Replaced the example with the real command so it matches Compose and no longer depends on a hard-coded table count (~760) that changes across ADempiere versions.