### PR TITLE
feat: re-apply DB passwords from the environment on every start

### DIFF
--- a/docker-compose/postgresql/custom-entrypoint.sh
+++ b/docker-compose/postgresql/custom-entrypoint.sh
@@ -1,0 +1,17 @@
+#!/usr/bin/env bash
+#
+# Custom entrypoint for the ADempiere PostgreSQL image.
+#
+# It launches sync-credentials.sh in the background (it self-waits for Postgres to accept
+# connections, then re-applies role passwords from the environment) and then hands off to the
+# stock postgres entrypoint unchanged. Running the sync in the background guarantees it never
+# blocks or alters PostgreSQL's own startup: if the sync fails for any reason, Postgres still
+# starts normally.
+#
+# This makes credential changes (edit env + stop-all + start-all) take effect on restart,
+# which the default image only does on the first initdb.
+set -e
+
+/usr/local/bin/sync-credentials.sh &
+
+exec docker-entrypoint.sh "$@"

--- a/docker-compose/postgresql/initdb.sh
+++ b/docker-compose/postgresql/initdb.sh
@@ -9,7 +9,11 @@ echo "Check if user 'adempiere' exists."
 if [ "$( psql -U $POSTGRES_USER -tAc "SELECT 1 FROM pg_roles WHERE rolname='adempiere'" )" != '1' ]; then
 	echo "The role 'adempiere' does not exist -->> it will be created and restored"
 	createuser -U postgres adempiere -dlrs
-	psql -U postgres -tAc "ALTER USER adempiere password 'adempiere';"
+	# Use a heredoc (not psql -c): psql only interpolates :'var' when reading from a
+	# script/stdin, not from a -c command string. This keeps special characters safe.
+	psql -U postgres -v apw="${ADEMPIERE_DB_PASSWORD:-adempiere}" <<'SQL'
+ALTER ROLE adempiere WITH PASSWORD :'apw';
+SQL
 fi
 
 # Test database existence

--- a/docker-compose/postgresql/postgres.Dockerfile
+++ b/docker-compose/postgresql/postgres.Dockerfile
@@ -25,3 +25,14 @@ COPY --chown=postgres:postgres initdb.sh /docker-entrypoint-initdb.d/
 COPY --chown=postgres:postgres after_run/*.sql /tmp/after_run/
 
 RUN chmod +x /docker-entrypoint-initdb.d/initdb.sh
+
+
+# Re-apply role passwords from the environment on EVERY start (the stock image only does this
+# on the first initdb). custom-entrypoint.sh runs sync-credentials.sh in the background and
+# then hands off to the stock postgres entrypoint unchanged.
+COPY --chown=postgres:postgres sync-credentials.sh custom-entrypoint.sh /usr/local/bin/
+RUN chmod +x /usr/local/bin/sync-credentials.sh /usr/local/bin/custom-entrypoint.sh
+
+# Setting ENTRYPOINT in a derived image resets the inherited CMD, so re-declare it.
+ENTRYPOINT ["custom-entrypoint.sh"]
+CMD ["postgres"]

--- a/docker-compose/postgresql/sync-credentials.sh
+++ b/docker-compose/postgresql/sync-credentials.sh
@@ -1,0 +1,72 @@
+#!/usr/bin/env bash
+#
+# Re-apply PostgreSQL role passwords from the environment on EVERY container start.
+#
+# Why: Postgres only applies POSTGRES_PASSWORD / creates roles during the initial initdb
+# (empty data directory). On an already-initialised database the env vars are ignored, so
+# editing them and restarting the stack would NOT change the credentials. This script closes
+# that gap: it runs on every start and re-applies the passwords, making the documented
+# "edit env + stop-all + start-all" flow actually work.
+#
+# It connects over the local unix socket (pg_hba `local all all trust`, the same way
+# initdb.sh connects), so it needs no existing password — avoiding the chicken-and-egg of a
+# TCP client that would require the OLD password to set a new one.
+#
+# ALTER ROLE is idempotent, so running this on an unchanged password is a no-op.
+
+set -uo pipefail
+
+PG_ADMIN="${POSTGRES_USER:-postgres}"
+SOCKET_DIR="/var/run/postgresql"
+
+log() { echo "[sync-credentials] $*"; }
+
+# Wait until Postgres accepts local connections (bounded, so a broken DB never hangs start-up).
+wait_ready() {
+    local waited=0 timeout=180
+    until pg_isready -U "$PG_ADMIN" -h "$SOCKET_DIR" -q; do
+        if [ "$waited" -ge "$timeout" ]; then
+            log "Postgres did not become ready within ${timeout}s; skipping credential sync."
+            return 1
+        fi
+        sleep 2
+        waited=$((waited + 2))
+    done
+    return 0
+}
+
+# apply <role> <password> — re-apply the password only if the role already exists and the
+# password value is non-empty. Runs as the postgres superuser over the local socket.
+# psql interpolates :"role" as a quoted identifier and :'pw' as a quoted literal, so
+# passwords with special characters are handled safely.
+apply() {
+    local role="$1" pw="$2"
+    [ -z "$pw" ] && { log "No password provided for role '$role'; skipping."; return 0; }
+
+    local exists
+    exists=$(psql -U "$PG_ADMIN" -d postgres -tAc \
+        "SELECT 1 FROM pg_roles WHERE rolname = '${role}'" 2>/dev/null)
+    if [ "$exists" != "1" ]; then
+        log "Role '$role' does not exist yet; skipping (will be created by initdb)."
+        return 0
+    fi
+
+    if psql -v ON_ERROR_STOP=1 -U "$PG_ADMIN" -d postgres \
+            -v role="$role" -v pw="$pw" >/dev/null 2>&1 <<'SQL'
+ALTER ROLE :"role" WITH PASSWORD :'pw';
+SQL
+    then
+        log "Password re-applied for role '$role'."
+    else
+        log "WARNING: could not re-apply password for role '$role'."
+    fi
+}
+
+main() {
+    wait_ready || return 0
+    apply "$PG_ADMIN" "${POSTGRES_PASSWORD:-}"
+    apply "adempiere" "${ADEMPIERE_DB_PASSWORD:-}"
+    log "Credential sync finished."
+}
+
+main

--- a/docs/security.md
+++ b/docs/security.md
@@ -108,7 +108,7 @@ See [Architecture - Network Architecture](./architecture.md#network-architecture
 | Service | Default User | Default Password | Environment Variable | Change Priority |
 |---------|--------------|------------------|---------------------|-----------------|
 | **PostgreSQL** | postgres | postgres | `POSTGRES_PASSWORD` | 🔴 CRITICAL |
-| **PostgreSQL** | adempiere | adempiere | `POSTGRES_ADEMPIERE_PASSWORD` | 🔴 CRITICAL |
+| **PostgreSQL** | adempiere | adempiere | `ADEMPIERE_DB_PASSWORD` | 🔴 CRITICAL |
 | **OpenSearch** | admin | admin | `OPENSEARCH_ADMIN_PASSWORD` | 🟡 HIGH |
 | **MinIO S3** | minioadmin | minioadmin | `MINIO_ROOT_USER`, `MINIO_ROOT_PASSWORD` | 🟡 HIGH |
 | **Keycloak** | admin | admin | `KEYCLOAK_ADMIN`, `KEYCLOAK_ADMIN_PASSWORD` | 🔴 CRITICAL |
@@ -122,7 +122,7 @@ See [Services - Service Access Summary](./services.md#service-access-summary) fo
    ```bash
    # PostgreSQL
    POSTGRES_PASSWORD=your-strong-password-here
-   POSTGRES_ADEMPIERE_PASSWORD=your-adempiere-password-here
+   ADEMPIERE_DB_PASSWORD=your-adempiere-password-here
 
    # OpenSearch
    OPENSEARCH_ADMIN_PASSWORD=your-opensearch-password-here
@@ -143,6 +143,23 @@ See [Services - Service Access Summary](./services.md#service-access-summary) fo
    ./stop-all.sh
    ./start-all.sh
    ```
+
+> **Note — which file to edit.** Apply the change to the **active `docker-compose/.env`** (or via
+> `override.env`). `start-all.sh` keeps an existing `.env`, so editing only `env_template.env` does
+> **not** affect an already-generated `.env`.
+>
+> **Note — when the change takes effect.** Editing the env var only sets the *initial* value for
+> services that persist their credentials in a data volume. This stack handles the common cases:
+> - **PostgreSQL** — the `postgres` and `adempiere` role passwords are re-applied from the
+>   environment on **every** start, so `stop-all.sh` + `start-all.sh` updates them even on an
+>   already-initialised database.
+> - **MinIO** — applies `MINIO_ROOT_USER` / `MINIO_ROOT_PASSWORD` from the environment on every
+>   start; the change takes effect immediately.
+> - **Keycloak** — the admin account is created **only on the first start**; changing
+>   `KEYCLOAK_ADMIN_PASSWORD` afterwards has no effect on an existing Keycloak database. Rotate it
+>   from the Keycloak admin console instead.
+> - **OpenSearch** — an already-initialised cluster keeps its stored password; use the OpenSearch
+>   security tooling to rotate it.
 
 **Password Requirements:**
 - Minimum 16 characters


### PR DESCRIPTION
Editing POSTGRES_PASSWORD / ADEMPIERE_DB_PASSWORD and restarting the stack did not change the credentials on an existing database: Postgres only applies them during the initial initdb, and the `adempiere` role password was hard-coded in initdb.sh. security.md documents "edit env + stop-all + start-all" as the way to change credentials, so make that actually work for PostgreSQL.

- postgresql/sync-credentials.sh: on every start, wait for the local socket and re-apply the `postgres` and `adempiere` role passwords from the environment. Idempotent; connects over the local unix socket (`trust`), so no existing password is required (a TCP client would need the OLD password). Passwords are passed via psql `-v` + `:'pw'` quoting, so special chars are handled safely.
- postgresql/custom-entrypoint.sh: run the sync in the background, then exec the stock postgres entrypoint unchanged (the sync can never block or break Postgres start-up).
- postgres.Dockerfile: install both scripts and set the wrapper entrypoint; re-declare CMD because setting ENTRYPOINT in a derived image resets the inherited CMD.
- postgresql/initdb.sh: create the `adempiere` role with ADEMPIERE_DB_PASSWORD instead of a hard-coded 'adempiere' (falls back to 'adempiere' when unset — no regression).
- security.md: fix the env var name (POSTGRES_ADEMPIERE_PASSWORD -> ADEMPIERE_DB_PASSWORD) and document what re-applies on restart per service (Keycloak admin remains first-init-only).