### PR TITLE
docs: Correct DB restore conditions, optional seed and pinned version

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -314,7 +314,7 @@ docker-compose/
   If there is a database named `adempiere`, nothing happens.
   If there is no database named `adempiere`, the script checks if there is a database seed file in the backups directory.
   - If there is one, it launches a restore database.
-  - If there is none, the latest ADempiere seed is downloaded from Github and the restore is started with it.
+  - If there is none, a fixed ADempiere seed (version `ADEMPIERE_GITHUB_VERSION`, currently `3.9.4`) is downloaded from Github and the restore is started with it — so the local seed file is optional.
 - `postgresql/postgres_database`: directory on host used as the mounting point for the Postgres container's database.
   It implements persistence: this makes sure that the database is not deleted even if the docker containers, docker images and even docker are deleted.
   The database contents are always kept persistently on the host.

--- a/docs/backup-restore.md
+++ b/docs/backup-restore.md
@@ -294,15 +294,17 @@ The stack automatically restores from a seed file on first startup:
 
 **Conditions for automatic restore:**
 1. Database directory is empty: `postgresql/postgres_database/` has no contents
-2. Seed file exists: `postgresql/postgres_backups/seed.backup`
+2. Database `adempiere` does not yet exist
 3. Stack is starting for the first time
+
+A local seed file is **optional**: if `postgresql/postgres_backups/seed.backup` is present it is used, otherwise the seed is downloaded from GitHub (see below).
 
 **How it works:**
 - The `initdb.sh` script runs when PostgreSQL container starts
 - Checks if database "adempiere" exists
 - If not, looks for `seed.backup` file
 - Restores database from the seed file **with `pg_restore`**
-- If no seed file found, downloads latest from GitHub
+- If no seed file found, downloads a fixed version from GitHub (`ADEMPIERE_GITHUB_VERSION`, currently `3.9.4`) — not the latest release
 
 > **Important — the seed must be a custom-format dump.** `initdb.sh` restores `seed.backup` with `pg_restore`, which only reads PostgreSQL's **custom format** (`pg_dump --format=custom`, see [Custom Format Backup](#custom-format-backup-advanced)). A plain-SQL dump — the `.backup` produced by the quick and compressed procedures above — will **not** work as an auto-restore seed. To restore a plain-SQL dump, use the [Manual Restore](#manual-restore-existing-database) procedure (`psql`) instead.
 

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -138,11 +138,16 @@ Once the image have been downloaded, the container creation and start will last 
 
 #### c. Cases When Database Will Be Restored
 If
-- there is a file *seed.backup* (or as defined in `env_template.env`, variable `POSTGRES_RESTORE_FILE_NAME`) in directory `postgresql/postgres_backups`, and
-- the database as specified in `env_template.env`, variable `POSTGRES_DATABASE_NAME` does not exist in Postgres, and
-- directory `postgresql/postgres_database` does not exist.
+- the database `adempiere` does not exist in Postgres (the name is hardcoded in `postgresql/initdb.sh`; there is no `POSTGRES_DATABASE_NAME` variable), and
+- directory `postgresql/postgres_database` does not exist (or has no contents).
 
 *The database  will be restored*.
+
+The seed source is chosen automatically:
+- if a file *seed.backup* (or as defined in `env_template.env`, variable `POSTGRES_RESTORE_FILE_NAME`) exists in directory `postgresql/postgres_backups`, it is used;
+- otherwise a fixed ADempiere seed is downloaded from GitHub (version `ADEMPIERE_GITHUB_VERSION`, currently `3.9.4`).
+
+So the local seed file is **optional**: when it is absent, the restore falls back to the downloaded seed.
 
 #### d. Cases When Database Will Not Be Restored
 The execution of `postgresql/initdb.sh` will be skipped if


### PR DESCRIPTION
The docs described the automatic database restore inaccurately in three ways. Align them with what postgresql/initdb.sh actually does.

- Seed is optional, not mandatory: initdb.sh downloads the seed from GitHub when no local seed.backup is present, so a missing seed file is a valid case (installation.md, backup-restore.md, architecture.md).
- The downloaded seed is a pinned version, not "latest": it is ADEMPIERE_GITHUB_VERSION (currently 3.9.4), not the latest release (backup-restore.md, architecture.md).
- Remove the non-existent POSTGRES_DATABASE_NAME variable: the database name "adempiere" is hardcoded in initdb.sh (installation.md).