### PR TITLE
docs: Fix false claim that start-all.sh assembles docker-compose.yml

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -265,9 +265,9 @@ docker-compose/
 ├── env_template.env          # Main configuration — edit this, not .env
 ├── override_template.env     # Template for machine-specific overrides — copy to override.env and set values
 ├── override.env              # (not in git) Active overrides: values here replace env_template.env defaults in .env
-├── docker-compose.yml        # All service definitions with profiles (assembled by start-all.sh)
-├── start-all.sh              # Start stack script (assembles docker-compose.yml, activates profiles)
-├── stop-all.sh               # Stop stack script (also deletes assembled docker-compose.yml)
+├── docker-compose.yml        # All service definitions with profiles (static, committed as-is)
+├── start-all.sh              # Start stack script (creates host dirs, prepares .env, activates profiles)
+├── stop-all.sh               # Stop stack script (docker compose down; removes .env)
 ├── stop-and-delete-all.sh           # Complete cleanup script
 ├── generate-env.sh                  # Wrapper: calls generate_env.py with default paths
 ├── generate_env.py                  # Env generator: merges env_template.env + override.env → .env

--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -62,8 +62,8 @@ docker ps -a --format "{{.ID}}: {{.Names}}"
 # List all services defined in docker-compose.yml
 docker compose config --services
 
-# Note: docker-compose.yml must exist
-# If not assembled yet, run: ./start-all.sh
+# Note: run this from the docker-compose/ directory, where the
+# committed docker-compose.yml lives (it is static, not generated)
 ```
 
 ### View Docker Images

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -121,7 +121,7 @@ Or name the profile explicitly:
 
 The script `start-all.sh [parameter]` carries out the steps of the automatic installation.
 
-Depending on the parameter -that BTW selects the profile- the script assembles the services out of file **docker-compose.yml** by including to the project only the services that have the profile set.
+Depending on the parameter -that BTW selects the profile- Docker Compose activates, from the static file **docker-compose.yml**, only the services that have the given profile set. The file is committed as-is; `start-all.sh` does not generate or assemble it — it just exports `COMPOSE_PROFILES` and runs `docker compose up`.
 
 If no flag and/or parameter is given, the call will default to `docker compose -f docker-compose.yml` for the services combination **all**.
 If directories `postgresql/postgres_database` and `postgresql/postgres_backups` do not exist, they are created.


### PR DESCRIPTION
docker-compose.yml is a single static file committed to the repo. The docs described it as dynamically assembled/generated by start-all.sh, which never happens: start-all.sh only creates host directories, prepares .env, exports COMPOSE_PROFILES and runs `docker compose up`, letting Docker Compose activate the services whose profile is selected.

- installation.md: the parameter selects a profile; Docker Compose activates the matching services from the static file — start-all.sh does not generate or assemble the compose file.
- architecture.md (file tree): docker-compose.yml is static/committed; start-all.sh prepares dirs/.env and activates profiles; stop-all.sh runs `docker compose down` and removes .env (it does not delete the compose file).
- debugging.md: drop the "if not assembled yet" note; the committed docker-compose.yml is static, not generated.