### PR TITLE
docs: Describe what stop-all.sh really does (down + remove .env)

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -144,7 +144,8 @@ docker compose stop
 # Stop and remove containers (preserves volumes and data)
 docker compose down
 
-# For complete cleanup, see: ./stop-all.sh or ./stop-and-delete-all.sh
+# ./stop-all.sh              → docker compose down + removes .env (keeps volumes/data)
+# ./stop-and-delete-all.sh   → complete/destructive cleanup (also deletes volumes and images)
 ```
 
 ### Recreate All Services

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -333,6 +333,8 @@ cd docker-compose
 ./stop-all.sh
 ```
 
+This runs `docker compose down` (removes the containers and the network but **keeps** the database volume and its data) and removes the generated `.env` file. It does **not** delete the `docker-compose.yml` file, which is static and committed. To also delete volumes, images and data, use `stop-and-delete-all.sh` (see [Step 8](#8-delete-all-docker-objects)).
+
 ### 8. Delete All Docker Objects
 Sometimes, due to different reasons, you need to undo everything you have created on Docker and start anew. This is mostly in development, not in production.
 Then:


### PR DESCRIPTION
stop-all.sh runs `docker compose down` (no -v): it removes the containers and the network but keeps the database volume and its data, and then removes the generated .env. It does not delete docker-compose.yml (which is static and committed) and it is not a "complete cleanup" — that is stop-and-delete-all.sh.

- installation.md (Step 7): state that stop-all.sh does `docker compose down` keeping the data volume and removes .env, and that it does not delete the compose file; point to Step 8 for full deletion.
- debugging.md ("Stop Entire Stack"): stop listing stop-all.sh under "complete cleanup"; distinguish it (down + removes .env, keeps data) from the destructive stop-and-delete-all.sh.