### PR TITLE
docs: Fix working directory for scripts in troubleshooting/debugging

### DIFF
--- a/docs/debugging.md
+++ b/docs/debugging.md
@@ -419,7 +419,8 @@ docker exec -i adempiere-ui-gateway.postgresql \
   psql -U adempiere -d adempiere \
   < postgresql/postgres_backups/<your-backup-file>.backup
 
-# Automated backup script
+# Automated backup script (lives in docs/scripts/, run from the repo root)
+cd ..
 ./docs/scripts/04-backup-database.sh
 ```
 
@@ -577,7 +578,7 @@ For expected health check timings, see [Architecture - Health Checks](./architec
 
 ## Utility Scripts
 
-The project includes diagnostic scripts in `docs/scripts/` for common debugging tasks.
+The project includes diagnostic scripts in `docs/scripts/` for common debugging tasks. Unlike the rest of this guide, run these from the **repository root** (not `docker-compose/`) — the `./docs/scripts/...` paths below are relative to it.
 
 ### Timezone Diagnostic Scripts
 

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -175,6 +175,8 @@ sudo lsof -i :55432
 - Or change the port in `env_template.env`
 
 ```bash
+cd docker-compose/
+
 # Edit env_template.env
 nano env_template.env
 
@@ -220,6 +222,8 @@ ls -la postgresql/postgres_database/
 Solution: Delete the database directory and restart:
 
 ```bash
+cd docker-compose/
+
 # Stop containers
 ./stop-all.sh
 
@@ -280,6 +284,8 @@ You want a fresh restore, but the database already exists and restore is skipped
 
 
 ```bash
+cd docker-compose/
+
 # Stop all containers
 ./stop-all.sh
 
@@ -556,7 +562,8 @@ nano docker-compose/env_template.env
 # Set HOST_IP to your actual IP or domain
 HOST_IP=192.168.1.100
 
-# Restart
+# Restart (the scripts live in docker-compose/)
+cd docker-compose/
 ./stop-all.sh
 ./start-all.sh
 ```
@@ -636,6 +643,7 @@ nmcli device disconnect wlan0
 Then restart the full stack so Docker recreates the containers and the bridge network:
 
 ```bash
+cd docker-compose/
 sudo ./stop-all.sh      # docker compose down — removes containers and network, keeps the database volume
 sudo ./start-all.sh
 ```
@@ -1196,7 +1204,9 @@ docker exec adempiere-ui-gateway.nginx-ui-gateway nginx -s reload
 # Check the current value
 grep COMPOSE_PROJECT_NAME docker-compose/env_template.env
 
-# After changing it, restart the stack so .env is regenerated:
+# After changing it, restart the stack so .env is regenerated
+# (the scripts live in docker-compose/):
+cd docker-compose/
 ./stop-all.sh
 ./start-all.sh
 ```


### PR DESCRIPTION
Commands that call docker-compose/ scripts (./stop-all.sh, ./start-all.sh) and repo-root scripts (docs/scripts/*) assumed the wrong current directory, so copy-pasting them fails with "No such file or directory".

- troubleshooting.md: add `cd docker-compose/` before ./stop-all.sh / ./start-all.sh in the blocks that lacked it (port conflict, database restore x2, HOST_IP change, dual-NIC routing, COMPOSE_PROJECT_NAME). Two of those mixed docker-compose/-prefixed paths (repo-root CWD) with bare ./stop-all.sh (docker-compose/ CWD); now consistent.
- debugging.md: the docs/scripts/* helpers live at the repo root, but the guide's global CWD is docker-compose/. Note that the Utility Scripts run from the repo root, and `cd ..` before the backup-script call.